### PR TITLE
Use pattern matching for Player in event handlers

### DIFF
--- a/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
+++ b/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
@@ -108,11 +108,9 @@ public class Listeners implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onClick(InventoryClickEvent event) {
-        if (!(event.getWhoClicked() instanceof Player)) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
-
-        Player player = (Player) event.getWhoClicked();
 
         Inventory clickedInventory = event.getClickedInventory();
         if (clickedInventory != null) {
@@ -160,11 +158,9 @@ public class Listeners implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onDrag(InventoryDragEvent event) {
-        if (!(event.getWhoClicked() instanceof Player)) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
-
-        Player player = (Player) event.getWhoClicked();
 
         Inventory clickedInventory = event.getInventory();
         if (clickedInventory != null) {


### PR DESCRIPTION
Refactored InventoryClickEvent and InventoryDragEvent handlers to use Java pattern matching for instanceof when checking and casting Player. This simplifies the code and improves readability.